### PR TITLE
Remove merge commits from release notes

### DIFF
--- a/scripts/create_release_notes.sh
+++ b/scripts/create_release_notes.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 
-# Get the latest tag
 last_tag=$(git describe --abbrev=0 --tags)
 
-# Get the commit messages since the last tag
-commits=$(git log $last_tag..HEAD --pretty=format:"%s")
+commits_since_last_tag=$(git log $last_tag..HEAD --no-merges --pretty=format:"%s")
 
 notes_file="release_notes.txt"
 
-if [ -z "$commits" ]; then
+if [ -z "$commits_since_last_tag" ]; then
   echo "No changes from previous release" >> "$notes_file"
 else
-  # Write the release notes to a file
   echo "Release Notes:" > "$notes_file"
   echo "" >> "$notes_file"
   echo "Since the last tag ($last_tag), the following changes have been made:" >> "$notes_file"
   echo "" >> "$notes_file"
-  echo "$commits" >> "$notes_file"
+  echo "$commits_since_last_tag" >> "$notes_file"
 fi


### PR DESCRIPTION
The script will no longer append merge commits to release_notes.txt

example:
```
Release Notes:

Since the last tag (v0.1.0), the following changes have been made:

Add codecov to unit tests
Add CodeQL workflow
Bump golang from 1.20.0-alpine3.17 to 1.20.1-alpine3.17
Bump github.com/prometheus/common from 0.37.0 to 0.40.0
Add dependabot config
Use checkout@v3 instead of v2
Add SHA256 sum generation (#20)
Extract github user to env variable (#18)
Rename NodestatsResponse to NodeStatsResponse
Improve nodestats collector test
Change go version used in workflow
Remove unnecessary fetcher package
Improve node info test to check if all metrics are present
Add expose to Dockerfile
Update metrics in README
Add code for checking if logstash is up

```