### PR TITLE
Add Helm chart for the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,14 @@ tmp/
 
 # Release notes temporary file
 release_notes.txt
+
+# Helm artifacts
+charts/
+*.tgz
+tmpcharts/
+tmp-charts/
+_debug.yml
+_debug*.yml
+_debug/
+_debug.yaml
+_debug*.yaml

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: logstash-exporter
+description: Prometheus exporter for Logstash written in Go
+type: application
+version: v1.0.2
+appVersion: 1.0.2

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "logstash-exporter.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "logstash-exporter.name" -}}
+{{- printf "%s" .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "logstash-exporter.serviceAccountName" -}}
+{{/*
+By default we want service account name to be the same as fullname
+but this may change in the future, so for easier usage this is extracted
+to a separate template.
+*/}}
+{{- include "logstash-exporter.fullname" . }}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "logstash-exporter.fullname" . }}
+  labels:
+    app: {{ include "logstash-exporter.name" . }}
+    release: {{ .Release.Name }}
+    {{- with .Values.deployment.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  spec:
+    replicas: {{ required "deployment.replicas is required" .Values.deployment.replicas }}
+    selector:
+      matchLabels:
+        app: {{ include "logstash-exporter.name" . }}
+        release: {{ .Release.Name }}
+    strategy:
+      rollingUpdate:
+        maxSurge: {{ required "deployment.rollingUpdate.maxSurge is required" .Values.deployment.rollingUpdate.maxSurge }}
+        maxUnavailable: {{ required "deployment.rollingUpdate.maxUnavailable is required" .Values.deployment.rollingUpdate.maxUnavailable }}
+      type: RollingUpdate
+    securityContext:
+      {{- toYaml .Values.deployment.securityContext | nindent 6 }}
+    dnsConfig:
+      {{- toYaml .Values.deployment.dnsConfig | nindent 6 }}
+    restartPolicy: {{ required "deployment.restartPolicy is required" .Values.deployment.restartPolicy }}
+    template:
+      metadata:
+        labels:
+          app: {{ include "logstash-exporter.name" . }}
+          release: {{ .Release.Name }}
+        {{- with .Values.deployment.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.deployment.podAnnotations }}
+        annotations:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        {{- if .Values.deployment.imagePullSecrets }}
+        imagePullSecrets:
+        {{- range $pullSecret := .Values.deployment.pullSecret }}
+        - name: {{ $pullSecret }}
+        {{- end }}
+        {{- end }}
+
+        {{- if .Values.serviceAccount.enabled }}
+        {{- if .Values.serviceAccount.create }}
+        serviceAccountName: {{ include "logstash-exporter.serviceAccountName" . }}
+        {{- else }}
+        serviceAccountName: {{ .Values.serviceAccount.name }}
+        {{- end }}
+        {{- end }}
+
+        {{- if .Values.deployment.priorityClassName }}
+        priorityClassName: {{ .Values.deployment.priorityClassName }}
+        {{- end }}
+
+        {{- if .Values.deployment.tolerations }}
+        {{- toYaml .Values.deployment.tolerations | nindent 8 }}
+        {{- end }}
+
+        {{- if .Values.deployment.affinity }}
+        {{- toYaml .Values.deployment.affinity | nindent 8 }}
+        {{- end }}
+
+        {{- if .Values.deployment.nodeSelector }}
+        {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+        {{- end }}
+        containers:
+        - name: exporter
+          env:
+          - name: LOGSTASH_URL
+            value: {{ required "logstash.url is required" .Values.logstash.url | quote }}
+          - name: PORT
+            value: {{ required "service.port is required" .Values.service.port | quote }}
+          {{- range $key, $value := .Values.deployment.env }}
+          - name: {{ $key | quote }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- range $key, $value := .Values.deployment.envFrom }}
+          - name: {{ $key | quote }}
+            valueFrom:
+              {{- toYaml $value | nindent 14 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.deployment.resources }}
+          resources:
+            {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+          - name: http
+            containerPort: {{ required "service.port is required" .Values.service.port }}
+

--- a/chart/templates/service-account.yaml
+++ b/chart/templates/service-account.yaml
@@ -1,0 +1,13 @@
+{{- if (and .Values.serviceAccount.create .Values.serviceAccount.enabled) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "logstash-exporter.serviceAccountName" . }}
+  labels:
+    app: {{ template "logstash-exporter.name" . }}
+    release: {{ .Release.Name }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{ end -}}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "logstash-exporter.fullname" . }}
+  labels:
+    app: {{ template "logstash-exporter.name" . }}
+    release: {{ .Release.Name }}
+    {{- if .Values.service.annotations }}
+    annotations:
+    {{ toYaml .Values.service.annotations | indent 6 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.port }}
+    protocol: TCP
+  selector:
+    app: {{ template "logstash-exporter.name" . }}
+    release: {{ .Release.Name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,54 @@
+logstash:
+  url: "http://logstash:9600"
+
+image:
+  repository: "kuskoman/logstash-exporter"
+  tag: "v1.0.2"
+  pullPolicy: IfNotPresent
+
+deployment:
+  replicas: 1
+  restartPolicy: Always
+  annotations: {}
+  labels: {}
+  pullSecret: []
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  podAnnotations: {}
+  podLabels: {}
+  affinity: {}
+  env: {}
+  envFrom: []
+  priorityClassName: ""
+  dnsConfig: {}
+  securityContext: {}
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+service:
+  type: ClusterIP
+  port: 9198
+  annotations: {}
+  labels: {}
+
+serviceAccount:
+  enabled: false
+  create: false
+  name: ""
+  annotations: {}


### PR DESCRIPTION
This PR will serve as a kind of a todo:
- [x] implement basic resources in chart
- [ ] create pipeline for the chart:
  - [ ] add chart linting
  - [ ] add chart testing
  - [ ] consider (and add if possible) chart testing on real kubernetes
- [ ] add versioning chart for the chart:
  - [ ] version the chart along with main tags
  - [ ] version the app inside chart with main tags
- [ ] publish the charts somehow and somewhere