### PR TITLE
Helm Chart Fixes + Multi-Arch Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ build-windows: out/main-windows
 build-docker:
 	docker build -t logstash-exporter .
 
+# Builds for Linux X86, Apple Silicon/AWS Graviton. Requires docker buildx (Docker 19.03+)
+build-docker-multi:
+	docker buildx build --platform linux/amd64,linux/arm64 -t logstash-exporter .
+
 clean:
 	rm -f $(GOOS_EXES)
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ All configuration variables can be checked in the [config directory](./config/).
 - `make run`: Runs the Go Exporter application.
 - `make build-<OS>`: Builds a binary executable for the specified OS (`<OS>` can be linux, darwin, or windows).
 - `make build-docker`: Builds a Docker image for the Go Exporter application.
+- `make build-docker-multi`: Builds a multi-arch Docker image (`amd64` and `arm64`) for the Go Exporter application.
 - `make clean`: Deletes all binary executables in the out directory.
 - `make test`: Runs all tests.
 - `make compose`: Starts a Docker-compose configuration.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,6 +1,19 @@
+{{/*
+Create a default fully qualified app name.
+If release name contains chart name it will be used as a full name.
+*/}}
 {{- define "logstash-exporter.fullname" -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{- define "logstash-exporter.name" -}}
 {{- printf "%s" .Chart.Name | trunc 63 | trimSuffix "-" -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -10,102 +10,117 @@ metadata:
     {{- end }}
   {{- with .Values.deployment.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-  spec:
-    replicas: {{ required "deployment.replicas is required" .Values.deployment.replicas }}
-    selector:
-      matchLabels:
+spec:
+  replicas: {{ required "deployment.replicas is required" .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "logstash-exporter.name" . }}
+      release: {{ .Release.Name }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ required "deployment.rollingUpdate.maxSurge is required" .Values.deployment.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ required "deployment.rollingUpdate.maxUnavailable is required" .Values.deployment.rollingUpdate.maxUnavailable }}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
         app: {{ include "logstash-exporter.name" . }}
         release: {{ .Release.Name }}
-    strategy:
-      rollingUpdate:
-        maxSurge: {{ required "deployment.rollingUpdate.maxSurge is required" .Values.deployment.rollingUpdate.maxSurge }}
-        maxUnavailable: {{ required "deployment.rollingUpdate.maxUnavailable is required" .Values.deployment.rollingUpdate.maxUnavailable }}
-      type: RollingUpdate
-    securityContext:
-      {{- toYaml .Values.deployment.securityContext | nindent 6 }}
-    dnsConfig:
-      {{- toYaml .Values.deployment.dnsConfig | nindent 6 }}
-    restartPolicy: {{ required "deployment.restartPolicy is required" .Values.deployment.restartPolicy }}
-    template:
-      metadata:
-        labels:
-          app: {{ include "logstash-exporter.name" . }}
-          release: {{ .Release.Name }}
         {{- with .Values.deployment.podLabels }}
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.deployment.podAnnotations }}
-        annotations:
-          {{ toYaml . | nindent 10 }}
+      {{- with .Values.deployment.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $pullSecret := .Values.deployment.pullSecret }}
+      - name: {{ $pullSecret }}
+      {{- end }}
+      {{- end }}
+
+      {{- if .Values.serviceAccount.enabled }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "logstash-exporter.serviceAccountName" . }}
+      {{- else }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      {{- end }}
+
+      {{- if .Values.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.deployment.priorityClassName }}
+      {{- end }}
+
+      restartPolicy: {{ required "deployment.restartPolicy is required" .Values.deployment.restartPolicy }}
+
+      {{- if .Values.deployment.tolerations }}
+      tolerations:
+      {{- toYaml .Values.deployment.tolerations | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values.deployment.affinity }}
+      affinity:
+      {{- toYaml .Values.deployment.affinity | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values.deployment.securityContext }}
+      securityContext:
+      {{- toYaml .Values.deployment.securityContext | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values.deployment.dnsConfig }}
+      dnsConfig:
+      {{- toYaml .Values.deployment.dnsConfig | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: exporter
+        env:
+        - name: LOGSTASH_URL
+          value: {{ required "logstash.url is required" .Values.logstash.url | quote }}
+        - name: PORT
+          value: {{ required "service.port is required" .Values.service.port | quote }}
+        {{- range $key, $value := .Values.deployment.env }}
+        - name: {{ $key | quote }}
+          value: {{ $value | quote }}
         {{- end }}
-      spec:
-        {{- if .Values.deployment.imagePullSecrets }}
-        imagePullSecrets:
-        {{- range $pullSecret := .Values.deployment.pullSecret }}
-        - name: {{ $pullSecret }}
+        {{- range $key, $value := .Values.deployment.envFrom }}
+        - name: {{ $key | quote }}
+          valueFrom:
+            {{- toYaml $value | nindent 14 }}
         {{- end }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+        {{- if .Values.deployment.resources }}
+        resources:
+          {{- toYaml .Values.deployment.resources | nindent 12 }}
         {{- end }}
 
-        {{- if .Values.serviceAccount.enabled }}
-        {{- if .Values.serviceAccount.create }}
-        serviceAccountName: {{ include "logstash-exporter.serviceAccountName" . }}
-        {{- else }}
-        serviceAccountName: {{ .Values.serviceAccount.name }}
-        {{- end }}
+        {{- if .Values.deployment.livenessProbe }}
+        livenessProbe:
+          {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
         {{- end }}
 
-        {{- if .Values.deployment.priorityClassName }}
-        priorityClassName: {{ .Values.deployment.priorityClassName }}
+        {{- if .Values.deployment.readinessProbe }}
+        readinessProbe:
+          {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
         {{- end }}
 
-        {{- if .Values.deployment.tolerations }}
-        {{- toYaml .Values.deployment.tolerations | nindent 8 }}
+        {{- with .Values.deployment.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
         {{- end }}
-
-        {{- if .Values.deployment.affinity }}
-        {{- toYaml .Values.deployment.affinity | nindent 8 }}
-        {{- end }}
-
-        {{- if .Values.deployment.nodeSelector }}
-        {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
-        {{- end }}
-        containers:
-        - name: exporter
-          env:
-          - name: LOGSTASH_URL
-            value: {{ required "logstash.url is required" .Values.logstash.url | quote }}
-          - name: PORT
-            value: {{ required "service.port is required" .Values.service.port | quote }}
-          {{- range $key, $value := .Values.deployment.env }}
-          - name: {{ $key | quote }}
-            value: {{ $value | quote }}
-          {{- end }}
-          {{- range $key, $value := .Values.deployment.envFrom }}
-          - name: {{ $key | quote }}
-            valueFrom:
-              {{- toYaml $value | nindent 14 }}
-          {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.deployment.resources }}
-          resources:
-            {{- toYaml .Values.deployment.resources | nindent 12 }}
-          {{- end }}
-          {{- with .Values.deployment.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.deployment.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.deployment.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-          - name: http
-            containerPort: {{ required "service.port is required" .Values.service.port }}
+        ports:
+        - name: http
+          containerPort: {{ required "service.port is required" .Values.service.port }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,6 +6,8 @@ image:
   tag: "v1.0.2"
   pullPolicy: IfNotPresent
 
+fullnameOverride: ""
+
 deployment:
   replicas: 1
   restartPolicy: Always
@@ -24,19 +26,15 @@ deployment:
   dnsConfig: {}
   securityContext: {}
   livenessProbe:
-    enabled: true
+    httpGet:
+      path: /health
+      port: 9198
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 3
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 5
-    successThreshold: 1
-    failureThreshold: 3
+  readinessProbe: {}
   rollingUpdate:
     maxSurge: 1
     maxUnavailable: 0


### PR DESCRIPTION
1. Fixes the draft Helm chart, which had indentation issues, and several pod-level configs which needed to be in the inner-level template. (tested with Helm v3.11.2)
2. Fixes `livenessProbe` to use the `/health` endpoint and default service port.
3. The deployment's `fullname` would default to `logstash-exporter-logstash-exporter`, so I borrowed [Helm's default template helper](https://github.com/helm/helm/blob/e007c900ce5f2233c8583565d5ba1b0433b1a213/pkg/chartutil/create.go#L433-L449) for this. This can be manually set via `values.yaml`.
4. Added `docker buildx` to the Makefile for the zen of running locally on an M1, but using on an AMD64 K8s cluster. Also for AWS Graviton instances.