### PR TITLE
Fix last_error field not being properly defined

### DIFF
--- a/fetcher/responses/__snapshots__/nodestats_response_test.snap
+++ b/fetcher/responses/__snapshots__/nodestats_response_test.snap
@@ -125,7 +125,16 @@ responses.NodeStatsResponse{
                     },
                 },
             },
-            Reloads:     struct { LastFailureTimestamp interface {} "json:\"last_failure_timestamp\""; Successes int "json:\"successes\""; Failures int "json:\"failures\""; LastSuccessTimestamp interface {} "json:\"last_success_timestamp\""; LastError interface {} "json:\"last_error\"" }{},
+            Reloads: responses.PipelineReloadResponse{
+                LastFailureTimestamp: time.Date(2023, time.April, 20, 20, 0, 32, 437218256, time.UTC),
+                Successes:            3,
+                Failures:             1,
+                LastSuccessTimestamp: time.Date(2023, time.April, 20, 22, 30, 32, 437218256, time.UTC),
+                LastError:            responses.LastError{
+                    Message:   "No configuration found in the configured sources.",
+                    Backtrace: {"org/logstash/execution/AbstractPipelineExt.java:151:in `reload_pipeline'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:181:in `block in reload_pipeline'", "/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/stud-0.0.23/lib/stud/task.rb:24:in `block in initialize'"},
+                },
+            },
             Queue:       struct { Type string "json:\"type\""; EventsCount int "json:\"events_count\""; QueueSizeInBytes int "json:\"queue_size_in_bytes\""; MaxQueueSizeInBytes int "json:\"max_queue_size_in_bytes\"" }{Type:"memory", EventsCount:0, QueueSizeInBytes:0, MaxQueueSizeInBytes:0},
             Hash:        "a73729cc9c29203931db21553c5edba063820a7e40d16cb5053be75cc3811a17",
             EphemeralID: "a5c63d09-1ba6-4d67-90a5-075f468a7ab0",

--- a/fetcher/responses/__snapshots__/nodestats_response_test.snap
+++ b/fetcher/responses/__snapshots__/nodestats_response_test.snap
@@ -73,7 +73,7 @@ responses.NodeStatsResponse{
                 Outputs: {
                 },
             },
-            Reloads:     struct { LastFailureTimestamp interface {} "json:\"last_failure_timestamp\""; Successes int "json:\"successes\""; Failures int "json:\"failures\""; LastSuccessTimestamp interface {} "json:\"last_success_timestamp\""; LastError interface {} "json:\"last_error\"" }{},
+            Reloads:     responses.PipelineReloadResponse{},
             Queue:       struct { Type string "json:\"type\""; EventsCount int "json:\"events_count\""; QueueSizeInBytes int "json:\"queue_size_in_bytes\""; MaxQueueSizeInBytes int "json:\"max_queue_size_in_bytes\"" }{},
             Hash:        "",
             EphemeralID: "",

--- a/fetcher/responses/nodestats_response.go
+++ b/fetcher/responses/nodestats_response.go
@@ -159,13 +159,7 @@ type SinglePipelineResponse struct {
 			} `json:"events"`
 		} `json:"outputs"`
 	} `json:"plugins"`
-	Reloads struct {
-		LastFailureTimestamp interface{} `json:"last_failure_timestamp"`
-		Successes            int         `json:"successes"`
-		Failures             int         `json:"failures"`
-		LastSuccessTimestamp interface{} `json:"last_success_timestamp"`
-		LastError            interface{} `json:"last_error"`
-	} `json:"reloads"`
+	Reloads PipelineReloadResponse `json:"reloads"`
 	Queue struct {
 		Type                string `json:"type"`
 		EventsCount         int    `json:"events_count"`
@@ -212,14 +206,21 @@ type PipelineLogstashMonitoringResponse struct {
 		Filters []interface{} `json:"filters"`
 		Outputs []interface{} `json:"outputs"`
 	} `json:"plugins"`
-	Reloads struct {
-		LastFailureTimestamp *time.Time `json:"last_failure_timestamp,omitempty"`
-		Successes            int        `json:"successes"`
-		Failures             int        `json:"failures"`
-		LastSuccessTimestamp *time.Time `json:"last_success_timestamp,omitempty"`
-		LastError            string     `json:"last_error,omitempty"`
-	} `json:"reloads"`
+	Reloads PipelineReloadResponse `json:"reloads"`
 	Queue interface{} `json:"queue,omitempty"`
+}
+
+type PipelineReloadResponse struct {
+	LastFailureTimestamp *time.Time `json:"last_failure_timestamp,omitempty"`
+	Successes            int        `json:"successes"`
+	Failures             int        `json:"failures"`
+	LastSuccessTimestamp *time.Time `json:"last_success_timestamp,omitempty"`
+	LastError            LastError  `json:"last_error,omitempty"`
+}
+
+type LastError struct {
+	Message string `json:"message"`
+	Backtrace []string `json:"backtrace"`
 }
 
 type ReloadResponse struct {

--- a/fixtures/node_stats.json
+++ b/fixtures/node_stats.json
@@ -202,11 +202,18 @@
         ]
       },
       "reloads": {
-        "last_failure_timestamp": null,
-        "successes": 0,
-        "failures": 0,
-        "last_success_timestamp": null,
-        "last_error": null
+        "last_failure_timestamp":  "2023-04-20T20:00:32.437218256Z",
+        "successes": 3,
+        "failures": 1,
+        "last_success_timestamp": "2023-04-20T22:30:32.437218256Z",
+        "last_error": {
+          "message": "No configuration found in the configured sources.",
+          "backtrace": [
+            "org/logstash/execution/AbstractPipelineExt.java:151:in `reload_pipeline'",
+            "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:181:in `block in reload_pipeline'",
+            "/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/stud-0.0.23/lib/stud/task.rb:24:in `block in initialize'"
+          ]
+        }
       },
       "queue": {
         "type": "memory",


### PR DESCRIPTION
Resolves #96. The `PipelineReloadResponse.pipelines.reloads.last_error` is defined in `fetcher/responses/nodestats_response.go` as a string, however it is an object with `message` and `backtrace` properties.

This contains the fix, and an update snap of the unmarshalled struct. Some other values in the fixture exist due to cherry-picking from the next PR.