### PR TITLE
Docker-compose: Logstash supports hot config reload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 8
-    command: logstash --config.reload.automatic
+    command: /usr/local/bin/docker-entrypoint --config.reload.automatic
     ports:
       - ${LOGSTASH_PORT:-5044}:5044
       - ${LOGSTASH_STATS_PORT:-9600}:9600

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 8
+    command: logstash --config.reload.automatic
     ports:
       - ${LOGSTASH_PORT:-5044}:5044
       - ${LOGSTASH_STATS_PORT:-9600}:9600


### PR DESCRIPTION
Resolves #97. Passes the `--config.reload.automatic` to the [entrypoint used in the official image](https://github.com/elastic/logstash/blob/main/docker/data/logstash/bin/docker-entrypoint).