### PR TITLE
Limit Java cheap size for dev docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - xpack.security.enabled=false
       - xpack.security.http.ssl.enabled=false
       - xpack.security.transport.ssl.enabled=false
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
     healthcheck:
       test:
         - "CMD"


### PR DESCRIPTION
I found out that elasticsearch is taking about 30gb of ram on my work machine, which takes nearly all of my resources. This does not happen on all machines, but this fixes it on this specific one.