### PR TITLE
Add support for a version command to check the binary version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ GOOS_EXES := $(foreach goos,$(GOOS_VALUES),$(if $(filter windows,$(goos)),out/ma
 
 GITHUB_REPO := github.com/kuskoman/logstash-exporter
 VERSION ?= $(shell git symbolic-ref --short HEAD)
+SEMANTIC_VERSION ?= $(shell git describe --tags --abbrev=1 --dirty 2> /dev/null)
 GIT_COMMIT := $(shell git rev-parse HEAD)
 DOCKER_IMG ?= "logstash-exporter"
 
@@ -20,6 +21,7 @@ all: $(GOOS_BINARIES)
 VERSIONINFO_PKG := config
 ldflags := -s -w \
 	-X '$(GITHUB_REPO)/$(VERSIONINFO_PKG).Version=$(VERSION)' \
+	-X '$(GITHUB_REPO)/$(VERSIONINFO_PKG).SemanticVersion=$(SEMANTIC_VERSION)' \
 	-X '$(GITHUB_REPO)/$(VERSIONINFO_PKG).GitCommit=$(GIT_COMMIT)' \
 	-X '$(GITHUB_REPO)/$(VERSIONINFO_PKG).BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%S%Z)'
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -13,6 +15,14 @@ import (
 )
 
 func main() {
+	version := flag.Bool("version", false, "prints the version and exits")
+
+	flag.Parse()
+	if *version {
+		fmt.Printf("%s\n", config.SemanticVersion)
+		return
+	}
+
 	warn := godotenv.Load()
 	if warn != nil {
 		log.Println(warn)

--- a/config/version.go
+++ b/config/version.go
@@ -9,6 +9,11 @@ var (
 	// Version is the current version of Logstash Exporter.
 	Version = "unknown"
 
+	// Semantic Version is the current version of the Logstash Exporter
+	// This version uses the latest tag as well as the sha prefix
+	// if there have been any commits since the last tag
+	SemanticVersion = "unknown"
+
 	// GitCommit is the git commit hash of the current build.
 	GitCommit = "unknown"
 
@@ -19,26 +24,28 @@ var (
 // GetVersionInfo returns a VersionInfo struct with the current build information.
 func GetVersionInfo() *VersionInfo {
 	return &VersionInfo{
-		Version:   Version,
-		GitCommit: GitCommit,
-		GoVersion: runtime.Version(),
-		BuildArch: runtime.GOARCH,
-		BuildOS:   runtime.GOOS,
-		BuildDate: BuildDate,
+		Version:         Version,
+		SemanticVersion: SemanticVersion,
+		GitCommit:       GitCommit,
+		GoVersion:       runtime.Version(),
+		BuildArch:       runtime.GOARCH,
+		BuildOS:         runtime.GOOS,
+		BuildDate:       BuildDate,
 	}
 }
 
 // VersionInfo contains the current build information.
 type VersionInfo struct {
-	Version   string
-	GitCommit string
-	GoVersion string
-	BuildArch string
-	BuildOS   string
-	BuildDate string
+	Version         string
+	SemanticVersion string
+	GitCommit       string
+	GoVersion       string
+	BuildArch       string
+	BuildOS         string
+	BuildDate       string
 }
 
 // String returns a string representation of the VersionInfo struct.
 func (v *VersionInfo) String() string {
-	return fmt.Sprintf("Version: %s, GitCommit: %s, GoVersion: %s, BuildArch: %s, BuildOS: %s, BuildDate: %s", v.Version, v.GitCommit, v.GoVersion, v.BuildArch, v.BuildOS, v.BuildDate)
+	return fmt.Sprintf("Version: %s, SemanticVersion: %s, GitCommit: %s, GoVersion: %s, BuildArch: %s, BuildOS: %s, BuildDate: %s", v.Version, v.SemanticVersion, v.GitCommit, v.GoVersion, v.BuildArch, v.BuildOS, v.BuildDate)
 }

--- a/config/version_test.go
+++ b/config/version_test.go
@@ -12,6 +12,10 @@ func TestGetBuildInfo(t *testing.T) {
 		t.Error("Expected Version to be set")
 	}
 
+	if versionInfo.SemanticVersion == "" {
+		t.Error("Expected SemanticVersion to be set")
+	}
+
 	if versionInfo.GitCommit == "" {
 		t.Error("Expected GitCommit to be set")
 	}
@@ -35,15 +39,16 @@ func TestGetBuildInfo(t *testing.T) {
 
 func TestVersionInfoString(t *testing.T) {
 	versionInfo := &VersionInfo{
-		Version:   "test-version",
-		GitCommit: "test-commit",
-		GoVersion: "test-go-version",
-		BuildArch: "test-arch",
-		BuildOS:   "test-os",
-		BuildDate: "test-date",
+		Version:         "test-version",
+		SemanticVersion: "v0.0.1-0548a52",
+		GitCommit:       "test-commit",
+		GoVersion:       "test-go-version",
+		BuildArch:       "test-arch",
+		BuildOS:         "test-os",
+		BuildDate:       "test-date",
 	}
 
-	expectedString := "Version: test-version, GitCommit: test-commit, GoVersion: test-go-version, BuildArch: test-arch, BuildOS: test-os, BuildDate: test-date"
+	expectedString := "Version: test-version, SemanticVersion: v0.0.1-0548a52, GitCommit: test-commit, GoVersion: test-go-version, BuildArch: test-arch, BuildOS: test-os, BuildDate: test-date"
 	versionInfoString := versionInfo.String()
 
 	if versionInfoString != expectedString {

--- a/server/versioninfo_test.go
+++ b/server/versioninfo_test.go
@@ -89,7 +89,7 @@ func TestHandleVersionInfo(t *testing.T) {
 		}
 
 		firstWrite := string(w.writes[0])
-		expectedFirstWrite := `{"Version":"version","GitCommit":"git commit","GoVersion":"go version","BuildArch":"build arch","BuildOS":"build os","BuildDate":"build date"}`
+		expectedFirstWrite := `{"Version":"version","SemanticVersion":"","GitCommit":"git commit","GoVersion":"go version","BuildArch":"build arch","BuildOS":"build os","BuildDate":"build date"}`
 		expectedFirstWrite = expectedFirstWrite + "\n"
 		if firstWrite != expectedFirstWrite {
 			t.Errorf("expected first write to be %s, but got: %s", expectedFirstWrite, firstWrite)


### PR DESCRIPTION
Adds a simple semantic version configuration and flag to print the version and exit. Test coverage is present for the general additions to version info, however here are some additional test cases I ran manually.


Version on the current branch
```
; make out/main-darwin                          
CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -ldflags="-s -w -X 'github.com/kuskoman/logstash-exporter/config.Version=mikey/version-command' -X 'github.com/kuskoman/logstash-exporter/config.SemanticVersion=v1.5.4-3-g5fd1' -X 'github.com/kuskoman/logstash-exporter/config.GitCommit=5fd14993d6e767e0ba81c4aac0bdeedc5658a6a0' -X 'github.com/kuskoman/logstash-exporter/config.BuildDate=2023-10-13T21:59:38UTC'" -o out/main-darwin cmd/exporter/main.go
; ./out/main-darwin -version
v1.5.4-3-g5fd1
```

Version when adding a tag
```
; git tag v1.5.5
; make out/main-darwin      
CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -ldflags="-s -w -X 'github.com/kuskoman/logstash-exporter/config.Version=mikey/version-command' -X 'github.com/kuskoman/logstash-exporter/config.SemanticVersion=v1.5.5' -X 'github.com/kuskoman/logstash-exporter/config.GitCommit=5fd14993d6e767e0ba81c4aac0bdeedc5658a6a0' -X 'github.com/kuskoman/logstash-exporter/config.BuildDate=2023-10-13T22:01:19UTC'" -o out/main-darwin cmd/exporter/main.go
; ./out/main-darwin -version
v1.5.5
```

Version when the commit is dirty
```
; make out/main-darwin      
CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -ldflags="-s -w -X 'github.com/kuskoman/logstash-exporter/config.Version=mikey/version-command' -X 'github.com/kuskoman/logstash-exporter/config.SemanticVersion=v1.5.4-3-g5fd1-dirty' -X 'github.com/kuskoman/logstash-exporter/config.GitCommit=5fd14993d6e767e0ba81c4aac0bdeedc5658a6a0' -X 'github.com/kuskoman/logstash-exporter/config.BuildDate=2023-10-13T22:00:34UTC'" -o out/main-darwin cmd/exporter/main.go
; ./out/main-darwin -version
v1.5.4-3-g5fd1-dirty
```