### PR TITLE
Update Dockerfile to run as "nobody" user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
     -X ${GITHUB_REPO}/config.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     -o main cmd/exporter/main.go
 
+RUN grep "nobody:x:65534" /etc/passwd > /app/user
 
 FROM scratch as release
 
 COPY --from=build /app/main /app/main
+COPY --from=build /app/user /etc/passwd
 
 EXPOSE 9198
-
+USER 65534
 ENTRYPOINT ["/app/main"]


### PR DESCRIPTION
Modification for #200, reuse `nobody` entry in `/etc/passwd` from alpine image to allow the application to run with the `nobody` user.

