### PR TITLE
Remove label logic from client

### DIFF
--- a/collectors/collector_manager.go
+++ b/collectors/collector_manager.go
@@ -28,7 +28,7 @@ func getClientsForEndpoints(endpoints []*config.LogstashServer) []logstashclient
 	clients := make([]logstashclient.Client, len(endpoints))
 
 	for i, endpoint := range endpoints {
-		clients[i] = logstashclient.NewClient(endpoint.Host, endpoint.Labels)
+		clients[i] = logstashclient.NewClient(endpoint.Host)
 	}
 
 	return clients

--- a/collectors/collector_manager_test.go
+++ b/collectors/collector_manager_test.go
@@ -15,8 +15,7 @@ func TestNewCollectorManager(t *testing.T) {
 
 	t.Run("multiple endpoints", func(t *testing.T) {
 		endpoint1 := &config.LogstashServer{
-			Host:   "http://localhost:9600",
-			Labels: map[string]string{"foo": "bar"},
+			Host: "http://localhost:9600",
 		}
 
 		endpoint2 := &config.LogstashServer{

--- a/collectors/nodeinfo/nodeinfo_collector_test.go
+++ b/collectors/nodeinfo/nodeinfo_collector_test.go
@@ -40,10 +40,6 @@ func (m *mockClient) GetEndpoint() string {
 	return ""
 }
 
-func (m *mockClient) GetLabels() map[string]string {
-	return nil
-}
-
 type errorMockClient struct{}
 
 func (m *errorMockClient) GetNodeInfo(ctx context.Context) (*responses.NodeInfoResponse, error) {
@@ -56,10 +52,6 @@ func (m *errorMockClient) GetNodeStats(ctx context.Context) (*responses.NodeStat
 
 func (m *errorMockClient) GetEndpoint() string {
 	return ""
-}
-
-func (m *errorMockClient) GetLabels() map[string]string {
-	return nil
 }
 
 func TestCollectNotNil(t *testing.T) {

--- a/collectors/nodestats/nodestats_collector_test.go
+++ b/collectors/nodestats/nodestats_collector_test.go
@@ -40,10 +40,6 @@ func (m *mockClient) GetEndpoint() string {
 	return ""
 }
 
-func (m *mockClient) GetLabels() map[string]string {
-	return nil
-}
-
 type errorMockClient struct{}
 
 func (m *errorMockClient) GetNodeInfo(ctx context.Context) (*responses.NodeInfoResponse, error) {
@@ -56,10 +52,6 @@ func (m *errorMockClient) GetNodeStats(ctx context.Context) (*responses.NodeStat
 
 func (m *errorMockClient) GetEndpoint() string {
 	return ""
-}
-
-func (m *errorMockClient) GetLabels() map[string]string {
-	return nil
 }
 
 func TestCollectNotNil(t *testing.T) {

--- a/config/exporter_config.go
+++ b/config/exporter_config.go
@@ -20,8 +20,7 @@ var (
 
 // LogstashServer represents individual Logstash server configuration
 type LogstashServer struct {
-	Host   string            `yaml:"url"`
-	Labels map[string]string `yaml:"labels"`
+	Host string `yaml:"url"`
 }
 
 // LogstashConfig holds the configuration for all Logstash servers

--- a/fetcher/logstash_client/client.go
+++ b/fetcher/logstash_client/client.go
@@ -14,40 +14,29 @@ type Client interface {
 	GetNodeStats(ctx context.Context) (*responses.NodeStatsResponse, error)
 
 	GetEndpoint() string
-	GetLabels() map[string]string
 }
 
 // DefaultClient is the default implementation of the Client interface
 type DefaultClient struct {
 	httpClient *http.Client
 	endpoint   string
-	labels     map[string]string
 }
 
 func (client *DefaultClient) GetEndpoint() string {
 	return client.endpoint
 }
 
-func (client *DefaultClient) GetLabels() map[string]string {
-	return client.labels
-}
-
 const defaultLogstashEndpoint = "http://localhost:9600"
 
 // NewClient returns a new instance of the DefaultClient configured with the given endpoint
-func NewClient(endpoint string, labels map[string]string) Client {
+func NewClient(endpoint string) Client {
 	if endpoint == "" {
 		endpoint = defaultLogstashEndpoint
-	}
-
-	if labels == nil {
-		labels = make(map[string]string)
 	}
 
 	return &DefaultClient{
 		httpClient: &http.Client{},
 		endpoint:   endpoint,
-		labels:     labels,
 	}
 }
 

--- a/fetcher/logstash_client/client_test.go
+++ b/fetcher/logstash_client/client_test.go
@@ -20,7 +20,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("should return a new client for the default endpoint", func(t *testing.T) {
 		t.Parallel()
 
-		client := NewClient("", nil)
+		client := NewClient("")
 
 		if client.(*DefaultClient).endpoint != defaultLogstashEndpoint {
 			t.Errorf("expected endpoint to be %s, got %s", defaultLogstashEndpoint, client.(*DefaultClient).endpoint)
@@ -31,34 +31,11 @@ func TestNewClient(t *testing.T) {
 		t.Parallel()
 
 		expectedEndpoint := "http://localhost:9601"
-		client := NewClient(expectedEndpoint, nil)
+		client := NewClient(expectedEndpoint)
 
 		receivedEndpoint := client.GetEndpoint()
 		if receivedEndpoint != expectedEndpoint {
 			t.Errorf("expected endpoint to be %s, got %s", expectedEndpoint, receivedEndpoint)
-		}
-	})
-
-	t.Run("should return a new client with the given labels", func(t *testing.T) {
-		t.Parallel()
-
-		expectedLabels := map[string]string{"foo": "bar"}
-		client := NewClient("", expectedLabels)
-
-		receivedLabels := client.GetLabels()
-		if receivedLabels["foo"] != expectedLabels["foo"] {
-			t.Errorf("expected label to be %s, got %s", expectedLabels["foo"], receivedLabels["foo"])
-		}
-	})
-
-	t.Run("should return a new client with an empty map if no labels are given", func(t *testing.T) {
-		t.Parallel()
-
-		client := NewClient("", nil)
-
-		receivedLabels := client.GetLabels()
-		if len(receivedLabels) != 0 {
-			t.Errorf("expected labels to be empty, got %v", receivedLabels)
 		}
 	})
 }

--- a/fetcher/logstash_client/queries_test.go
+++ b/fetcher/logstash_client/queries_test.go
@@ -22,7 +22,7 @@ func TestGetNodeInfo(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL, nil)
+		client := NewClient(ts.URL)
 
 		response, err := client.GetNodeInfo(context.Background())
 		if err != nil {
@@ -49,7 +49,7 @@ func TestGetNodeStats(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL, nil)
+		client := NewClient(ts.URL)
 
 		response, err := client.GetNodeStats(context.Background())
 		if err != nil {


### PR DESCRIPTION
The PR removes code related to #202 
Basically, since all instances now have hostname attached, a simple proxy should be able to solve the issue
I took some time to implement custom labeling, but it required way more logic than it gives benefits:
- config had to have custom logic for:
a. verifying label consistency
b. sorting label keys
c. sorting label values according to keys order
- client had to preserve either reference to config or reference to sorted slice of keys that are later on used to determine values to add to each and every metric
- since #79 was closed, there is no simple way that i know to treat these labels as const labels. therefore the logic is mixed with existing variableLabels logic which makes code way more unreadable than it currently is

I believe there are existing solutions allowing to relabel prometheus metrics.
In most cases hostname label alone should be sufficient, but if you are running multiple instances monitoring for example a local url you may consider using combination of both exporter and logstash address as a base for relabeling