### PR TITLE
Change data types to more reliable

### DIFF
--- a/internal/collectors/nodestats/nodestats_collector.go
+++ b/internal/collectors/nodestats/nodestats_collector.go
@@ -199,37 +199,37 @@ func (collector *NodestatsCollector) collectSingleInstance(client logstash_clien
 	// ************ MEMORY ************
 	memStats := nodeStats.Jvm.Mem
 	metricsHelper.NewIntMetric(collector.JvmMemHeapUsedPercent, prometheus.GaugeValue, memStats.HeapUsedPercent)
-	metricsHelper.NewIntMetric(collector.JvmMemHeapCommittedBytes, prometheus.GaugeValue, memStats.HeapCommittedInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemHeapMaxBytes, prometheus.GaugeValue, memStats.HeapMaxInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemHeapUsedBytes, prometheus.GaugeValue, memStats.HeapUsedInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemNonHeapCommittedBytes, prometheus.GaugeValue, memStats.NonHeapCommittedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemHeapCommittedBytes, prometheus.GaugeValue, memStats.HeapCommittedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemHeapMaxBytes, prometheus.GaugeValue, memStats.HeapMaxInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemHeapUsedBytes, prometheus.GaugeValue, memStats.HeapUsedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemNonHeapCommittedBytes, prometheus.GaugeValue, memStats.NonHeapCommittedInBytes)
 
 	//	  ********* POOLS *********
 	//          *** YOUNG ***
 	metricsHelper.Labels = []string{"young", endpoint}
-	metricsHelper.NewIntMetric(collector.JvmMemPoolPeakUsedInBytes, prometheus.GaugeValue, memStats.Pools.Young.PeakUsedInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolUsedInBytes, prometheus.GaugeValue, memStats.Pools.Young.UsedInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolPeakMaxInBytes, prometheus.GaugeValue, memStats.Pools.Young.PeakMaxInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolMaxInBytes, prometheus.GaugeValue, memStats.Pools.Young.MaxInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolCommittedInBytes, prometheus.GaugeValue, memStats.Pools.Young.CommittedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolPeakUsedInBytes, prometheus.GaugeValue, memStats.Pools.Young.PeakUsedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolUsedInBytes, prometheus.GaugeValue, memStats.Pools.Young.UsedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolPeakMaxInBytes, prometheus.GaugeValue, memStats.Pools.Young.PeakMaxInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolMaxInBytes, prometheus.GaugeValue, memStats.Pools.Young.MaxInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolCommittedInBytes, prometheus.GaugeValue, memStats.Pools.Young.CommittedInBytes)
 	//          *************
 
 	//           *** OLD ***
 	metricsHelper.Labels = []string{"old", endpoint}
-	metricsHelper.NewIntMetric(collector.JvmMemPoolPeakUsedInBytes, prometheus.GaugeValue, memStats.Pools.Old.PeakUsedInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolUsedInBytes, prometheus.GaugeValue, memStats.Pools.Old.UsedInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolPeakMaxInBytes, prometheus.GaugeValue, memStats.Pools.Old.PeakMaxInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolMaxInBytes, prometheus.GaugeValue, memStats.Pools.Old.MaxInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolCommittedInBytes, prometheus.GaugeValue, memStats.Pools.Old.CommittedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolPeakUsedInBytes, prometheus.GaugeValue, memStats.Pools.Old.PeakUsedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolUsedInBytes, prometheus.GaugeValue, memStats.Pools.Old.UsedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolPeakMaxInBytes, prometheus.GaugeValue, memStats.Pools.Old.PeakMaxInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolMaxInBytes, prometheus.GaugeValue, memStats.Pools.Old.MaxInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolCommittedInBytes, prometheus.GaugeValue, memStats.Pools.Old.CommittedInBytes)
 	//           ***********
 
 	//         *** SURVIVOR ***
 	metricsHelper.Labels = []string{"survivor", endpoint}
-	metricsHelper.NewIntMetric(collector.JvmMemPoolPeakUsedInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.PeakUsedInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolUsedInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.UsedInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolPeakMaxInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.PeakMaxInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolMaxInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.MaxInBytes)
-	metricsHelper.NewIntMetric(collector.JvmMemPoolCommittedInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.CommittedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolPeakUsedInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.PeakUsedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolUsedInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.UsedInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolPeakMaxInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.PeakMaxInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolMaxInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.MaxInBytes)
+	metricsHelper.NewInt64Metric(collector.JvmMemPoolCommittedInBytes, prometheus.GaugeValue, memStats.Pools.Survivor.CommittedInBytes)
 	//         ****************
 	//	  *************************
 	// ********************************
@@ -242,14 +242,14 @@ func (collector *NodestatsCollector) collectSingleInstance(client logstash_clien
 
 	// ************ PROCESS ************
 	procStats := nodeStats.Process
-	metricsHelper.NewUInt64Metric(collector.ProcessOpenFileDescriptors, prometheus.GaugeValue, procStats.OpenFileDescriptors)
-	metricsHelper.NewUInt64Metric(collector.ProcessMaxFileDescriptors, prometheus.GaugeValue, procStats.MaxFileDescriptors)
+	metricsHelper.NewInt64Metric(collector.ProcessOpenFileDescriptors, prometheus.GaugeValue, procStats.OpenFileDescriptors)
+	metricsHelper.NewInt64Metric(collector.ProcessMaxFileDescriptors, prometheus.GaugeValue, procStats.MaxFileDescriptors)
 	metricsHelper.NewIntMetric(collector.ProcessCpuPercent, prometheus.GaugeValue, procStats.CPU.Percent)
-	metricsHelper.NewUInt64Metric(collector.ProcessCpuTotalMillis, prometheus.CounterValue, procStats.CPU.TotalInMillis)
+	metricsHelper.NewInt64Metric(collector.ProcessCpuTotalMillis, prometheus.CounterValue, procStats.CPU.TotalInMillis)
 	metricsHelper.NewFloatMetric(collector.ProcessCpuLoadAverageOneM, prometheus.GaugeValue, procStats.CPU.LoadAverage.OneM)
 	metricsHelper.NewFloatMetric(collector.ProcessCpuLoadAverageFiveM, prometheus.GaugeValue, procStats.CPU.LoadAverage.FiveM)
 	metricsHelper.NewFloatMetric(collector.ProcessCpuLoadAverageFifteenM, prometheus.GaugeValue, procStats.CPU.LoadAverage.FifteenM)
-	metricsHelper.NewUInt64Metric(collector.ProcessMemTotalVirtual, prometheus.GaugeValue, procStats.Mem.TotalVirtualInBytes)
+	metricsHelper.NewInt64Metric(collector.ProcessMemTotalVirtual, prometheus.GaugeValue, procStats.Mem.TotalVirtualInBytes)
 	// *********************************
 
 	// ************ RELOADS ************
@@ -263,11 +263,11 @@ func (collector *NodestatsCollector) collectSingleInstance(client logstash_clien
 
 	// ************ EVENTS ************
 	eventsStats := nodeStats.Events
-	metricsHelper.NewUInt64Metric(collector.EventsIn, prometheus.GaugeValue, eventsStats.In)
-	metricsHelper.NewUInt64Metric(collector.EventsFiltered, prometheus.GaugeValue, eventsStats.Filtered)
-	metricsHelper.NewUInt64Metric(collector.EventsOut, prometheus.GaugeValue, eventsStats.Out)
-	metricsHelper.NewUInt64Metric(collector.EventsDurationInMillis, prometheus.GaugeValue, eventsStats.DurationInMillis)
-	metricsHelper.NewUInt64Metric(collector.EventsQueuePushDurationInMillis, prometheus.GaugeValue, eventsStats.QueuePushDurationInMillis)
+	metricsHelper.NewInt64Metric(collector.EventsIn, prometheus.GaugeValue, eventsStats.In)
+	metricsHelper.NewInt64Metric(collector.EventsFiltered, prometheus.GaugeValue, eventsStats.Filtered)
+	metricsHelper.NewInt64Metric(collector.EventsOut, prometheus.GaugeValue, eventsStats.Out)
+	metricsHelper.NewInt64Metric(collector.EventsDurationInMillis, prometheus.GaugeValue, eventsStats.DurationInMillis)
+	metricsHelper.NewInt64Metric(collector.EventsQueuePushDurationInMillis, prometheus.GaugeValue, eventsStats.QueuePushDurationInMillis)
 	// ********************************
 
 	// ************ FLOW ************

--- a/internal/collectors/nodestats/pipeline_subcollector.go
+++ b/internal/collectors/nodestats/pipeline_subcollector.go
@@ -142,9 +142,9 @@ func (subcollector *PipelineSubcollector) Collect(pipeStats *responses.SinglePip
 	// *******************
 
 	// ***** QUEUE *****
-	metricsHelper.NewUInt64Metric(subcollector.QueueEventsCount, prometheus.CounterValue, pipeStats.Queue.EventsCount)
-	metricsHelper.NewUInt64Metric(subcollector.QueueEventsQueueSize, prometheus.GaugeValue, pipeStats.Queue.QueueSizeInBytes)
-	metricsHelper.NewUInt64Metric(subcollector.QueueMaxQueueSizeInBytes, prometheus.GaugeValue, pipeStats.Queue.MaxQueueSizeInBytes)
+	metricsHelper.NewInt64Metric(subcollector.QueueEventsCount, prometheus.CounterValue, pipeStats.Queue.EventsCount)
+	metricsHelper.NewInt64Metric(subcollector.QueueEventsQueueSize, prometheus.GaugeValue, pipeStats.Queue.QueueSizeInBytes)
+	metricsHelper.NewInt64Metric(subcollector.QueueMaxQueueSizeInBytes, prometheus.GaugeValue, pipeStats.Queue.MaxQueueSizeInBytes)
 	// *****************
 
 	// ***** FLOW *****
@@ -164,9 +164,9 @@ func (subcollector *PipelineSubcollector) Collect(pipeStats *responses.SinglePip
 	// ***** DEAD LETTER QUEUE *****
 	deadLetterQueueStats := pipeStats.DeadLetterQueue
 	metricsHelper.NewIntMetric(subcollector.DeadLetterQueueMaxSizeInBytes, prometheus.GaugeValue, deadLetterQueueStats.MaxQueueSizeInBytes)
-	metricsHelper.NewUInt64Metric(subcollector.DeadLetterQueueSizeInBytes, prometheus.GaugeValue, deadLetterQueueStats.QueueSizeInBytes)
-	metricsHelper.NewUInt64Metric(subcollector.DeadLetterQueueDroppedEvents, prometheus.CounterValue, deadLetterQueueStats.DroppedEvents)
-	metricsHelper.NewUInt64Metric(subcollector.DeadLetterQueueExpiredEvents, prometheus.CounterValue, deadLetterQueueStats.ExpiredEvents)
+	metricsHelper.NewInt64Metric(subcollector.DeadLetterQueueSizeInBytes, prometheus.GaugeValue, deadLetterQueueStats.QueueSizeInBytes)
+	metricsHelper.NewInt64Metric(subcollector.DeadLetterQueueDroppedEvents, prometheus.CounterValue, deadLetterQueueStats.DroppedEvents)
+	metricsHelper.NewInt64Metric(subcollector.DeadLetterQueueExpiredEvents, prometheus.CounterValue, deadLetterQueueStats.ExpiredEvents)
 	// *****************************
 
 	// ===== PLUGINS =====

--- a/internal/fetcher/responses/__snapshots__/nodestats_response_test.snap
+++ b/internal/fetcher/responses/__snapshots__/nodestats_response_test.snap
@@ -13,39 +13,39 @@ responses.NodeStatsResponse{
     Pipeline:    responses.PipelineResponse{Workers:16, BatchSize:125, BatchDelay:50},
     Jvm:         responses.JvmResponse{
         Threads: struct { Count int "json:\"count\""; PeakCount int "json:\"peak_count\"" }{Count:60, PeakCount:60},
-        Mem:     struct { HeapUsedPercent int "json:\"heap_used_percent\""; HeapCommittedInBytes int "json:\"heap_committed_in_bytes\""; HeapMaxInBytes int "json:\"heap_max_in_bytes\""; HeapUsedInBytes int "json:\"heap_used_in_bytes\""; NonHeapUsedInBytes int "json:\"non_heap_used_in_bytes\""; NonHeapCommittedInBytes int "json:\"non_heap_committed_in_bytes\""; Pools struct { Young struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" } "json:\"young\""; Old struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" } "json:\"old\""; Survivor struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" } "json:\"survivor\"" } "json:\"pools\"" }{
+        Mem:     struct { HeapUsedPercent int "json:\"heap_used_percent\""; HeapCommittedInBytes int64 "json:\"heap_committed_in_bytes\""; HeapMaxInBytes int64 "json:\"heap_max_in_bytes\""; HeapUsedInBytes int64 "json:\"heap_used_in_bytes\""; NonHeapUsedInBytes int64 "json:\"non_heap_used_in_bytes\""; NonHeapCommittedInBytes int64 "json:\"non_heap_committed_in_bytes\""; Pools struct { Young responses.PoolResponse "json:\"young\""; Old responses.PoolResponse "json:\"old\""; Survivor responses.PoolResponse "json:\"survivor\"" } "json:\"pools\"" }{
             HeapUsedPercent:         27,
             HeapCommittedInBytes:    1073741824,
             HeapMaxInBytes:          1073741822,
             HeapUsedInBytes:         294044784,
             NonHeapUsedInBytes:      147703688,
             NonHeapCommittedInBytes: 155189248,
-            Pools:                   struct { Young struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" } "json:\"young\""; Old struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" } "json:\"old\""; Survivor struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" } "json:\"survivor\"" }{
-                Young:    struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" }{PeakMaxInBytes:-1, MaxInBytes:-1, CommittedInBytes:346030080, PeakUsedInBytes:326107136, UsedInBytes:180355072},
-                Old:      struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" }{PeakMaxInBytes:1073741824, MaxInBytes:1073741824, CommittedInBytes:687865856, PeakUsedInBytes:73986560, UsedInBytes:73986560},
-                Survivor: struct { PeakMaxInBytes int "json:\"peak_max_in_bytes\""; MaxInBytes int "json:\"max_in_bytes\""; CommittedInBytes int "json:\"committed_in_bytes\""; PeakUsedInBytes int "json:\"peak_used_in_bytes\""; UsedInBytes int "json:\"used_in_bytes\"" }{PeakMaxInBytes:-1, MaxInBytes:-1, CommittedInBytes:39845888, PeakUsedInBytes:39703152, UsedInBytes:39703152},
+            Pools:                   struct { Young responses.PoolResponse "json:\"young\""; Old responses.PoolResponse "json:\"old\""; Survivor responses.PoolResponse "json:\"survivor\"" }{
+                Young:    responses.PoolResponse{PeakMaxInBytes:-1, MaxInBytes:-1, CommittedInBytes:346030080, PeakUsedInBytes:326107136, UsedInBytes:180355072},
+                Old:      responses.PoolResponse{PeakMaxInBytes:1073741824, MaxInBytes:1073741824, CommittedInBytes:687865856, PeakUsedInBytes:73986560, UsedInBytes:73986560},
+                Survivor: responses.PoolResponse{PeakMaxInBytes:-1, MaxInBytes:-1, CommittedInBytes:39845888, PeakUsedInBytes:39703152, UsedInBytes:39703152},
             },
         },
-        Gc: struct { Collectors struct { Young struct { CollectionCount int "json:\"collection_count\""; CollectionTimeInMillis int "json:\"collection_time_in_millis\"" } "json:\"young\""; Old struct { CollectionCount int "json:\"collection_count\""; CollectionTimeInMillis int "json:\"collection_time_in_millis\"" } "json:\"old\"" } "json:\"collectors\"" }{
-            Collectors: struct { Young struct { CollectionCount int "json:\"collection_count\""; CollectionTimeInMillis int "json:\"collection_time_in_millis\"" } "json:\"young\""; Old struct { CollectionCount int "json:\"collection_count\""; CollectionTimeInMillis int "json:\"collection_time_in_millis\"" } "json:\"old\"" }{
-                Young: struct { CollectionCount int "json:\"collection_count\""; CollectionTimeInMillis int "json:\"collection_time_in_millis\"" }{CollectionCount:8, CollectionTimeInMillis:224},
-                Old:   struct { CollectionCount int "json:\"collection_count\""; CollectionTimeInMillis int "json:\"collection_time_in_millis\"" }{},
+        Gc: struct { Collectors struct { Young responses.CollectorResponse "json:\"young\""; Old responses.CollectorResponse "json:\"old\"" } "json:\"collectors\"" }{
+            Collectors: struct { Young responses.CollectorResponse "json:\"young\""; Old responses.CollectorResponse "json:\"old\"" }{
+                Young: responses.CollectorResponse{CollectionCount:8, CollectionTimeInMillis:224},
+                Old:   responses.CollectorResponse{},
             },
         },
         UptimeInMillis: 53120,
     },
     Process: responses.ProcessResponse{
-        OpenFileDescriptors:     0x62,
+        OpenFileDescriptors:     98,
         PeakOpenFileDescriptors: 98,
-        MaxFileDescriptors:      0x100000,
-        Mem:                     struct { TotalVirtualInBytes uint64 "json:\"total_virtual_in_bytes\"" }{TotalVirtualInBytes:0x22aa45000},
-        CPU:                     struct { TotalInMillis uint64 "json:\"total_in_millis\""; Percent int "json:\"percent\""; LoadAverage struct { OneM float64 "json:\"1m\""; FiveM float64 "json:\"5m\""; FifteenM float64 "json:\"15m\"" } "json:\"load_average\"" }{
-            TotalInMillis: 0x21084,
+        MaxFileDescriptors:      1048576,
+        Mem:                     struct { TotalVirtualInBytes int64 "json:\"total_virtual_in_bytes\"" }{TotalVirtualInBytes:9305346048},
+        CPU:                     struct { TotalInMillis int64 "json:\"total_in_millis\""; Percent int "json:\"percent\""; LoadAverage struct { OneM float64 "json:\"1m\""; FiveM float64 "json:\"5m\""; FifteenM float64 "json:\"15m\"" } "json:\"load_average\"" }{
+            TotalInMillis: 135300,
             Percent:       0,
             LoadAverage:   struct { OneM float64 "json:\"1m\""; FiveM float64 "json:\"5m\""; FifteenM float64 "json:\"15m\"" }{OneM:3.79, FiveM:1.29, FifteenM:0.46},
         },
     },
-    Events: responses.EventsResponse{In:0xfa1, Filtered:0xa, Out:0x2, DurationInMillis:0x5, QueuePushDurationInMillis:0x7},
+    Events: responses.EventsResponse{In:4001, Filtered:10, Out:2, DurationInMillis:5, QueuePushDurationInMillis:7},
     Flow:   responses.FlowResponse{
         InputThroughput:   struct { Current float64 "json:\"current\""; Lifetime float64 "json:\"lifetime\"" }{Current:1, Lifetime:117.4},
         FilterThroughput:  struct { Current float64 "json:\"current\""; Lifetime float64 "json:\"lifetime\"" }{Current:2.1, Lifetime:3.2},
@@ -82,8 +82,8 @@ responses.NodeStatsResponse{
                 },
             },
             Reloads:         responses.PipelineReloadResponse{},
-            Queue:           struct { Type string "json:\"type\""; EventsCount uint64 "json:\"events_count\""; QueueSizeInBytes uint64 "json:\"queue_size_in_bytes\""; MaxQueueSizeInBytes uint64 "json:\"max_queue_size_in_bytes\"" }{},
-            DeadLetterQueue: struct { MaxQueueSizeInBytes int "json:\"max_queue_size_in_bytes\""; QueueSizeInBytes uint64 "json:\"queue_size_in_bytes\""; DroppedEvents uint64 "json:\"dropped_events\""; ExpiredEvents uint64 "json:\"expired_events\""; StoragePolicy string "json:\"storage_policy\"" }{},
+            Queue:           struct { Type string "json:\"type\""; EventsCount int64 "json:\"events_count\""; QueueSizeInBytes int64 "json:\"queue_size_in_bytes\""; MaxQueueSizeInBytes int64 "json:\"max_queue_size_in_bytes\"" }{},
+            DeadLetterQueue: struct { MaxQueueSizeInBytes int "json:\"max_queue_size_in_bytes\""; QueueSizeInBytes int64 "json:\"queue_size_in_bytes\""; DroppedEvents int64 "json:\"dropped_events\""; ExpiredEvents int64 "json:\"expired_events\""; StoragePolicy string "json:\"storage_policy\"" }{},
             Hash:            "",
             EphemeralID:     "",
         },
@@ -159,8 +159,8 @@ responses.NodeStatsResponse{
                     Backtrace: {"org/logstash/execution/AbstractPipelineExt.java:151:in `reload_pipeline'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:181:in `block in reload_pipeline'", "/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/stud-0.0.23/lib/stud/task.rb:24:in `block in initialize'"},
                 },
             },
-            Queue:           struct { Type string "json:\"type\""; EventsCount uint64 "json:\"events_count\""; QueueSizeInBytes uint64 "json:\"queue_size_in_bytes\""; MaxQueueSizeInBytes uint64 "json:\"max_queue_size_in_bytes\"" }{Type:"memory", EventsCount:0x0, QueueSizeInBytes:0x0, MaxQueueSizeInBytes:0x0},
-            DeadLetterQueue: struct { MaxQueueSizeInBytes int "json:\"max_queue_size_in_bytes\""; QueueSizeInBytes uint64 "json:\"queue_size_in_bytes\""; DroppedEvents uint64 "json:\"dropped_events\""; ExpiredEvents uint64 "json:\"expired_events\""; StoragePolicy string "json:\"storage_policy\"" }{MaxQueueSizeInBytes:47244640256, QueueSizeInBytes:0x1, DroppedEvents:0x0, ExpiredEvents:0x0, StoragePolicy:"drop_newer"},
+            Queue:           struct { Type string "json:\"type\""; EventsCount int64 "json:\"events_count\""; QueueSizeInBytes int64 "json:\"queue_size_in_bytes\""; MaxQueueSizeInBytes int64 "json:\"max_queue_size_in_bytes\"" }{Type:"memory", EventsCount:0, QueueSizeInBytes:0, MaxQueueSizeInBytes:0},
+            DeadLetterQueue: struct { MaxQueueSizeInBytes int "json:\"max_queue_size_in_bytes\""; QueueSizeInBytes int64 "json:\"queue_size_in_bytes\""; DroppedEvents int64 "json:\"dropped_events\""; ExpiredEvents int64 "json:\"expired_events\""; StoragePolicy string "json:\"storage_policy\"" }{MaxQueueSizeInBytes:47244640256, QueueSizeInBytes:1, DroppedEvents:0, ExpiredEvents:0, StoragePolicy:"drop_newer"},
             Hash:            "a73729cc9c29203931db21553c5edba063820a7e40d16cb5053be75cc3811a17",
             EphemeralID:     "a5c63d09-1ba6-4d67-90a5-075f468a7ab0",
         },

--- a/internal/fetcher/responses/nodestats_response.go
+++ b/internal/fetcher/responses/nodestats_response.go
@@ -8,67 +8,56 @@ type PipelineResponse struct {
 	BatchDelay int `json:"batch_delay"`
 }
 
+type PoolResponse struct {
+	PeakMaxInBytes   int64 `json:"peak_max_in_bytes"`
+	MaxInBytes       int64 `json:"max_in_bytes"`
+	CommittedInBytes int64 `json:"committed_in_bytes"`
+	PeakUsedInBytes  int64 `json:"peak_used_in_bytes"`
+	UsedInBytes      int64 `json:"used_in_bytes"`
+}
+
+type CollectorResponse struct {
+	CollectionCount        int `json:"collection_count"`
+	CollectionTimeInMillis int `json:"collection_time_in_millis"`
+}
+
 type JvmResponse struct {
 	Threads struct {
 		Count     int `json:"count"`
 		PeakCount int `json:"peak_count"`
 	} `json:"threads"`
 	Mem struct {
-		HeapUsedPercent         int `json:"heap_used_percent"`
-		HeapCommittedInBytes    int `json:"heap_committed_in_bytes"`
-		HeapMaxInBytes          int `json:"heap_max_in_bytes"`
-		HeapUsedInBytes         int `json:"heap_used_in_bytes"`
-		NonHeapUsedInBytes      int `json:"non_heap_used_in_bytes"`
-		NonHeapCommittedInBytes int `json:"non_heap_committed_in_bytes"`
+		HeapUsedPercent         int   `json:"heap_used_percent"`
+		HeapCommittedInBytes    int64 `json:"heap_committed_in_bytes"`
+		HeapMaxInBytes          int64 `json:"heap_max_in_bytes"`
+		HeapUsedInBytes         int64 `json:"heap_used_in_bytes"`
+		NonHeapUsedInBytes      int64 `json:"non_heap_used_in_bytes"`
+		NonHeapCommittedInBytes int64 `json:"non_heap_committed_in_bytes"`
 		Pools                   struct {
-			Young struct {
-				PeakMaxInBytes   int `json:"peak_max_in_bytes"`
-				MaxInBytes       int `json:"max_in_bytes"`
-				CommittedInBytes int `json:"committed_in_bytes"`
-				PeakUsedInBytes  int `json:"peak_used_in_bytes"`
-				UsedInBytes      int `json:"used_in_bytes"`
-			} `json:"young"`
-			Old struct {
-				PeakMaxInBytes   int `json:"peak_max_in_bytes"`
-				MaxInBytes       int `json:"max_in_bytes"`
-				CommittedInBytes int `json:"committed_in_bytes"`
-				PeakUsedInBytes  int `json:"peak_used_in_bytes"`
-				UsedInBytes      int `json:"used_in_bytes"`
-			} `json:"old"`
-			Survivor struct {
-				PeakMaxInBytes   int `json:"peak_max_in_bytes"`
-				MaxInBytes       int `json:"max_in_bytes"`
-				CommittedInBytes int `json:"committed_in_bytes"`
-				PeakUsedInBytes  int `json:"peak_used_in_bytes"`
-				UsedInBytes      int `json:"used_in_bytes"`
-			} `json:"survivor"`
+			Young    PoolResponse `json:"young"`
+			Old      PoolResponse `json:"old"`
+			Survivor PoolResponse `json:"survivor"`
 		} `json:"pools"`
 	} `json:"mem"`
 	Gc struct {
 		Collectors struct {
-			Young struct {
-				CollectionCount        int `json:"collection_count"`
-				CollectionTimeInMillis int `json:"collection_time_in_millis"`
-			} `json:"young"`
-			Old struct {
-				CollectionCount        int `json:"collection_count"`
-				CollectionTimeInMillis int `json:"collection_time_in_millis"`
-			} `json:"old"`
+			Young CollectorResponse `json:"young"`
+			Old   CollectorResponse `json:"old"`
 		} `json:"collectors"`
 	} `json:"gc"`
 	UptimeInMillis int `json:"uptime_in_millis"`
 }
 
 type ProcessResponse struct {
-	OpenFileDescriptors     uint64 `json:"open_file_descriptors"`
-	PeakOpenFileDescriptors int64  `json:"peak_open_file_descriptors"`
-	MaxFileDescriptors      uint64 `json:"max_file_descriptors"`
+	OpenFileDescriptors     int64 `json:"open_file_descriptors"`
+	PeakOpenFileDescriptors int64 `json:"peak_open_file_descriptors"`
+	MaxFileDescriptors      int64 `json:"max_file_descriptors"`
 	Mem                     struct {
-		TotalVirtualInBytes uint64 `json:"total_virtual_in_bytes"`
+		TotalVirtualInBytes int64 `json:"total_virtual_in_bytes"`
 	} `json:"mem"`
 	CPU struct {
-		TotalInMillis uint64 `json:"total_in_millis"`
-		Percent       int    `json:"percent"`
+		TotalInMillis int64 `json:"total_in_millis"`
+		Percent       int   `json:"percent"`
 		LoadAverage   struct {
 			OneM     float64 `json:"1m"`
 			FiveM    float64 `json:"5m"`
@@ -78,11 +67,11 @@ type ProcessResponse struct {
 }
 
 type EventsResponse struct {
-	In                        uint64 `json:"in"`
-	Filtered                  uint64 `json:"filtered"`
-	Out                       uint64 `json:"out"`
-	DurationInMillis          uint64 `json:"duration_in_millis"`
-	QueuePushDurationInMillis uint64 `json:"queue_push_duration_in_millis"`
+	In                        int64 `json:"in"`
+	Filtered                  int64 `json:"filtered"`
+	Out                       int64 `json:"out"`
+	DurationInMillis          int64 `json:"duration_in_millis"`
+	QueuePushDurationInMillis int64 `json:"queue_push_duration_in_millis"`
 }
 
 type FlowResponse struct {
@@ -170,16 +159,16 @@ type SinglePipelineResponse struct {
 	Reloads PipelineReloadResponse `json:"reloads"`
 	Queue   struct {
 		Type                string `json:"type"`
-		EventsCount         uint64 `json:"events_count"`
-		QueueSizeInBytes    uint64 `json:"queue_size_in_bytes"`
-		MaxQueueSizeInBytes uint64 `json:"max_queue_size_in_bytes"`
+		EventsCount         int64  `json:"events_count"`
+		QueueSizeInBytes    int64  `json:"queue_size_in_bytes"`
+		MaxQueueSizeInBytes int64  `json:"max_queue_size_in_bytes"`
 	} `json:"queue"`
 	DeadLetterQueue struct {
 		MaxQueueSizeInBytes int `json:"max_queue_size_in_bytes"`
 		// todo: research how LastError is returned
-		QueueSizeInBytes uint64 `json:"queue_size_in_bytes"`
-		DroppedEvents    uint64 `json:"dropped_events"`
-		ExpiredEvents    uint64 `json:"expired_events"`
+		QueueSizeInBytes int64  `json:"queue_size_in_bytes"`
+		DroppedEvents    int64  `json:"dropped_events"`
+		ExpiredEvents    int64  `json:"expired_events"`
 		StoragePolicy    string `json:"storage_policy"`
 	} `json:"dead_letter_queue"`
 	Hash        string `json:"hash"`

--- a/internal/prometheus_helper/prometheus_helper.go
+++ b/internal/prometheus_helper/prometheus_helper.go
@@ -72,8 +72,8 @@ func (mh *SimpleMetricsHelper) NewIntMetric(desc *prometheus.Desc, metricType pr
 	mh.NewFloatMetric(desc, metricType, float64(value))
 }
 
-// NewUInt64Metric same as NewFloatMetric but for 'uint64' type
-func (mh *SimpleMetricsHelper) NewUInt64Metric(desc *prometheus.Desc, metricType prometheus.ValueType, value uint64) {
+// NewInt64Metric same as NewFloatMetric but for 'int64' type
+func (mh *SimpleMetricsHelper) NewInt64Metric(desc *prometheus.Desc, metricType prometheus.ValueType, value int64) {
 	mh.NewFloatMetric(desc, metricType, float64(value))
 }
 

--- a/internal/prometheus_helper/prometheus_helper_test.go
+++ b/internal/prometheus_helper/prometheus_helper_test.go
@@ -197,7 +197,6 @@ func TestSimpleMetricsHelper(t *testing.T) {
 		}
 		helper.NewFloatMetric(metricDesc, prometheus.GaugeValue, metricValue)
 		helper.NewIntMetric(metricDesc, prometheus.GaugeValue, int(metricValue))
-		helper.NewUInt64Metric(metricDesc, prometheus.GaugeValue, uint64(metricValue))
 
 		close(ch)
 


### PR DESCRIPTION
1. Remove UInt type -> some values may hold -1 instead
2. Use UInt64 for memory-related values

Relates to #314 