### PR TITLE
Fix intendation of securityContext

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
 
         {{- with .Values.deployment.securityContext }}
         securityContext:
-          {{- toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         ports:
         - name: http


### PR DESCRIPTION
The indentation should be 10 instead of 12 to make yamllint not complain.