### PR TITLE
Allow specifying pod and container securityContext and fix intendations to make yamllint happy

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -42,24 +42,26 @@
 
 ### Deployment settings
 
-| Name                           | Description                                                  | Value    |
-| ------------------------------ | ------------------------------------------------------------ | -------- |
-| `deployment.replicas`          | Number of replicas for the deployment                        | `1`      |
-| `deployment.restartPolicy`     | Restart policy for the deployment.                           | `Always` |
-| `deployment.annotations`       | Additional deployment annotations                            | `{}`     |
-| `deployment.labels`            | Additional deployment labels                                 | `{}`     |
-| `deployment.pullSecret`        | Kubernetes secret for pulling the image                      | `[]`     |
-| `deployment.resources`         | Resource requests and limits                                 | `{}`     |
-| `deployment.nodeSelector`      | Node selector for the deployment                             | `{}`     |
-| `deployment.tolerations`       | Tolerations for the deployment                               | `[]`     |
-| `deployment.podAnnotations`    | Additional pod annotations                                   | `{}`     |
-| `deployment.podLabels`         | Additional pod labels                                        | `{}`     |
-| `deployment.affinity`          | Affinity for the deployment                                  | `{}`     |
-| `deployment.env`               | Additional environment variables                             | `{}`     |
-| `deployment.envFrom`           | Additional environment variables from config maps or secrets | `[]`     |
-| `deployment.priorityClassName` | Priority class name for the deployment                       | `""`     |
-| `deployment.dnsConfig`         | DNS configuration for the deployment                         | `{}`     |
-| `deployment.securityContext`   | Security context for the deployment                          | `{}`     |
+| Name                                  | Description                                                            | Value    |
+| ------------------------------------- | ---------------------------------------------------------------------- | -------- |
+| `deployment.replicas`                 | Number of replicas for the deployment                                  | `1`      |
+| `deployment.restartPolicy`            | Restart policy for the deployment.                                     | `Always` |
+| `deployment.annotations`              | Additional deployment annotations                                      | `{}`     |
+| `deployment.labels`                   | Additional deployment labels                                           | `{}`     |
+| `deployment.pullSecret`               | Kubernetes secret for pulling the image                                | `[]`     |
+| `deployment.resources`                | Resource requests and limits                                           | `{}`     |
+| `deployment.nodeSelector`             | Node selector for the deployment                                       | `{}`     |
+| `deployment.tolerations`              | Tolerations for the deployment                                         | `[]`     |
+| `deployment.podAnnotations`           | Additional pod annotations                                             | `{}`     |
+| `deployment.podLabels`                | Additional pod labels                                                  | `{}`     |
+| `deployment.affinity`                 | Affinity for the deployment                                            | `{}`     |
+| `deployment.env`                      | Additional environment variables                                       | `{}`     |
+| `deployment.envFrom`                  | Additional environment variables from config maps or secrets           | `[]`     |
+| `deployment.priorityClassName`        | Priority class name for the deployment                                 | `""`     |
+| `deployment.dnsConfig`                | DNS configuration for the deployment                                   | `{}`     |
+| `deployment.securityContext`          | Security context for the deployment                                    | `{}`     |
+| `deployment.podSecurityContext`       | Security context for the deployment that only applies to the pod       | `{}`     |
+| `deployment.containerSecurityContext` | Security context for the deployment that only applies to the container | `{}`     |
 
 ### Liveness probe settings
 

--- a/chart/schema.json
+++ b/chart/schema.json
@@ -168,6 +168,16 @@
                     "description": "Security context for the deployment",
                     "default": {}
                 },
+                "podSecurityContext": {
+                    "type": "object",
+                    "description": "Security context for the deployment that only applies to the pod",
+                    "default": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "description": "Security context for the deployment that only applies to the container",
+                    "default": {}
+                },
                 "livenessProbe": {
                     "type": "object",
                     "properties": {

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -106,17 +106,17 @@ spec:
 
         {{- if .Values.deployment.resources }}
         resources:
-          {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- toYaml .Values.deployment.resources | nindent 10 }}
         {{- end }}
 
         {{- if .Values.deployment.livenessProbe }}
         livenessProbe:
-          {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
+          {{- toYaml .Values.deployment.livenessProbe | nindent 10 }}
         {{- end }}
 
         {{- if .Values.deployment.readinessProbe }}
         readinessProbe:
-          {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
+          {{- toYaml .Values.deployment.readinessProbe | nindent 10 }}
         {{- end }}
 
         {{- if or .Values.deployment.securityContext .Values.deployment.containerSecurityContext }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -72,9 +72,14 @@ spec:
       {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{- end }}
 
-      {{- if .Values.deployment.securityContext }}
+      {{- if or .Values.deployment.securityContext .Values.deployment.podSecurityContext }}
       securityContext:
-      {{- toYaml .Values.deployment.securityContext | nindent 8 }}
+        {{- if .Values.deployment.securityContext }}
+        {{- toYaml .Values.deployment.securityContext | nindent 8 }}
+        {{- end }}
+        {{- if .Values.deployment.podSecurityContext }}
+        {{- toYaml .Values.deployment.podSecurityContext | nindent 8 }}
+        {{- end }}
       {{- end }}
 
       {{- if .Values.deployment.dnsConfig }}
@@ -114,9 +119,14 @@ spec:
           {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
         {{- end }}
 
-        {{- with .Values.deployment.securityContext }}
+        {{- if or .Values.deployment.securityContext .Values.deployment.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 12 }}
+          {{- if .Values.deployment.securityContext }}
+          {{- toYaml .Values.deployment.securityContext | nindent 10 }}
+          {{- end }}
+          {{- if .Values.deployment.containerSecurityContext }}
+          {{- toYaml .Values.deployment.containerSecurityContext | nindent 10 }}
+          {{- end }}
         {{- end }}
         ports:
         - name: http

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -114,6 +114,12 @@ deployment:
   ## @param deployment.securityContext Security context for the deployment
   ##
   securityContext: {}
+  ## @param deployment.podSecurityContext Security context for the deployment that only applies to the pod
+  ##
+  podSecurityContext: {}
+  ## @param deployment.containerSecurityContext Security context for the deployment that only applies to the container
+  ##
+  containerSecurityContext: {}
   ## @section Liveness probe settings
   ##
   livenessProbe:


### PR DESCRIPTION
The available options of pod and container securityContext can differ. For example readOnlyRootFilesystem only applies to containers.

This pr allows setting securityContext for pods and containers while trying to keep backword compability in mind.

The intendation for some elements also was adjusted to make yamllint happy. Some elements where indented by 12 spaces instead of 10.