### PR TITLE
add HTTP_INSECURE config

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -41,6 +41,9 @@ func main() {
 	versionInfo := config.GetVersionInfo()
 	slog.Info(versionInfo.String())
 
+	httpInsecure := config.GetHttpInsecure()
+	slog.Debug("http insecure", "insecure", httpInsecure)
+
 	httpTimeout, err := config.GetHttpTimeout()
 	if err != nil {
 		slog.Error("failed to get http timeout", "err", err)
@@ -48,7 +51,7 @@ func main() {
 	}
 	slog.Debug("http timeout", "timeout", httpTimeout)
 
-	collectorManager := collectors.NewCollectorManager(logstashUrl, httpTimeout)
+	collectorManager := collectors.NewCollectorManager(logstashUrl, httpInsecure, httpTimeout)
 	appServer := server.NewAppServer(host, port, httpTimeout)
 	prometheus.MustRegister(collectorManager)
 

--- a/collectors/collector_manager.go
+++ b/collectors/collector_manager.go
@@ -25,8 +25,8 @@ type CollectorManager struct {
 	timeout         time.Duration
 }
 
-func NewCollectorManager(endpoint string, timeout time.Duration) *CollectorManager {
-	client := logstashclient.NewClient(endpoint)
+func NewCollectorManager(endpoint string, insecure bool, timeout time.Duration) *CollectorManager {
+	client := logstashclient.NewClient(endpoint, insecure)
 
 	collectors := getCollectors(client)
 

--- a/collectors/collector_manager_test.go
+++ b/collectors/collector_manager_test.go
@@ -14,7 +14,7 @@ const httpTimeout = 2 * time.Second
 
 func TestNewCollectorManager(t *testing.T) {
 	mockEndpoint := "http://localhost:9600"
-	cm := NewCollectorManager(mockEndpoint, httpTimeout)
+	cm := NewCollectorManager(mockEndpoint, false, httpTimeout)
 
 	if cm == nil {
 		t.Error("Expected collector manager to be initialized")

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -2,12 +2,14 @@ package config
 
 import (
 	"os"
+	"strconv"
 	"time"
 )
 
 const (
 	defaultHttpTimeout = time.Second * 2
 	httpTimeoutEnvVar  = "HTTP_TIMEOUT"
+	httpInsecureEnvVar = "HTTP_INSECURE"
 )
 
 func GetHttpTimeout() (time.Duration, error) {
@@ -22,4 +24,9 @@ func GetHttpTimeout() (time.Duration, error) {
 	}
 
 	return timeout, nil
+}
+
+func GetHttpInsecure() bool {
+	b, _ := strconv.ParseBool(os.Getenv(httpInsecureEnvVar))
+	return b
 }

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -44,3 +44,36 @@ func TestGetHttpTimeout(t *testing.T) {
 		}
 	})
 }
+
+func TestGetHttpInsecure(t *testing.T) {
+	t.Run("DefaultInsecure", func(t *testing.T) {
+		t.Parallel()
+		os.Unsetenv(httpInsecureEnvVar)
+		insecure := GetHttpInsecure()
+		if insecure != false {
+			t.Errorf("Expected default insecure of %v, got %v", false, insecure)
+		}
+	})
+
+	t.Run("CustomInsecure", func(t *testing.T) {
+		t.Parallel()
+		expectedInsecure := true
+		os.Setenv(httpInsecureEnvVar, "true")
+		defer os.Unsetenv(httpInsecureEnvVar)
+		insecure := GetHttpInsecure()
+		if insecure != expectedInsecure {
+			t.Errorf("Expected insecure of %v, got %v", expectedInsecure, insecure)
+		}
+	})
+
+	t.Run("InvalidInsecure", func(t *testing.T) {
+		t.Parallel()
+		expectedInsecure := false
+		os.Setenv(httpInsecureEnvVar, "invalid")
+		defer os.Unsetenv(httpInsecureEnvVar)
+		insecure := GetHttpInsecure()
+		if insecure != expectedInsecure {
+			t.Errorf("Expected insecure of %v, got %v", expectedInsecure, insecure)
+		}
+	})
+}

--- a/fetcher/logstash_client/client.go
+++ b/fetcher/logstash_client/client.go
@@ -2,6 +2,7 @@ package logstash_client
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 
@@ -23,14 +24,18 @@ type DefaultClient struct {
 const defaultLogstashEndpoint = "http://localhost:9600"
 
 // NewClient returns a new instance of the DefaultClient configured with the given endpoint
-func NewClient(endpoint string) Client {
+func NewClient(endpoint string, insecure bool) Client {
 	if endpoint == "" {
 		endpoint = defaultLogstashEndpoint
 	}
 
 	return &DefaultClient{
-		httpClient: &http.Client{},
-		endpoint:   endpoint,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+			},
+		},
+		endpoint: endpoint,
 	}
 }
 

--- a/fetcher/logstash_client/client_test.go
+++ b/fetcher/logstash_client/client_test.go
@@ -16,7 +16,7 @@ type TestResponse struct {
 
 func TestNewClient(t *testing.T) {
 	t.Run("should return a new client for the default endpoint", func(t *testing.T) {
-		client := NewClient("")
+		client := NewClient("", false)
 
 		if client.(*DefaultClient).endpoint != defaultLogstashEndpoint {
 			t.Errorf("expected endpoint to be %s, got %s", defaultLogstashEndpoint, client.(*DefaultClient).endpoint)
@@ -25,7 +25,7 @@ func TestNewClient(t *testing.T) {
 
 	t.Run("should return a new client for the given endpoint", func(t *testing.T) {
 		endpoint := "http://localhost:9601"
-		client := NewClient(endpoint)
+		client := NewClient(endpoint, false)
 
 		if client.(*DefaultClient).endpoint != endpoint {
 			t.Errorf("expected endpoint to be %s, got %s", endpoint, client.(*DefaultClient).endpoint)

--- a/fetcher/logstash_client/queries_test.go
+++ b/fetcher/logstash_client/queries_test.go
@@ -22,7 +22,7 @@ func TestGetNodeInfo(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(ts.URL, false)
 
 		response, err := client.GetNodeInfo(context.Background())
 		if err != nil {
@@ -49,7 +49,7 @@ func TestGetNodeStats(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(ts.URL, false)
 
 		response, err := client.GetNodeStats(context.Background())
 		if err != nil {


### PR DESCRIPTION
after upgrade eck operator to 2.13
the logstash create by operator will default enable ssl for http endpoint 9600
and the exporter will got this error
![image](https://github.com/kuskoman/logstash-exporter/assets/17737823/6a4647e7-75e4-4d0a-9f48-0a13f3a2e29e)
![image](https://github.com/kuskoman/logstash-exporter/assets/17737823/53b436dd-a464-431f-8550-0a7250f45e1a)
so i add a config to make a InsecureSkipVerify to http client to prevent this problem
