### PR TITLE
added pod ip variable

### DIFF
--- a/internal/k8s_controller/resource_handler.go
+++ b/internal/k8s_controller/resource_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -227,6 +228,24 @@ func (h *PodResourceHandler) processPod(pod *corev1.Pod) {
 	if instance == nil {
 		return
 	}
+
+	// Replace $(pod_ip) template variable with the actual pod IP
+	if pod.Status.PodIP != "" && instance.Host != "" {
+		// Replace $(pod_ip) in the URL string
+		replacedURL := strings.ReplaceAll(instance.Host, "$(pod_ip)", pod.Status.PodIP)
+		
+		// Validate the URL after replacement
+		if _, err := url.Parse(replacedURL); err == nil {
+			instance.Host = replacedURL
+		} else {
+			slog.Warn("failed to parse URL after pod_ip replacement",
+				"instance", instanceName,
+				"url", replacedURL,
+				"error", err)
+			return
+		}
+	}
+
 
 	slog.Info("discovered logstash instance from pod annotation",
 		"instance", instanceName,


### PR DESCRIPTION
Hi,

In Kubernetes environments, Pod IPs are ephemeral. Every time a Pod is recreated, it may receive a different IP address. This creates a problem when using the `logstash-exporter.io/url` annotation to point the exporter to the Logstash HTTP endpoint.

Currently, the annotation must contain a concrete, static URL. This means users who want to target the Pod IP directly have to implement workarounds such as:

* Adding an init container to Logstash Pods that patches the annotation with the current Pod IP
* Running side scripts or controllers to keep the annotation in sync
* Avoiding Pod IP usage altogether and relying on Services, which is not always desirable when scraping per-Pod endpoints

These approaches are operationally complex and push responsibility to users for something the exporter is already capable of knowing: it already queries the Kubernetes API and has access to the Pod IP during discovery.

This PR introduces a small substitution mechanism in the exporter: if the URL annotation contains `$(pod_ip)`, the exporter replaces it with the actual Pod IP obtained from the Kubernetes API during discovery.

Example:

```
logstash-exporter.io/url: http://$(pod_ip):9600
```

At runtime, this becomes:

```
http://10.42.1.23:9600
```

This keeps the annotation declarative and stable, avoids the need for init containers or external automation, and leverages information the exporter already has.

The change is minimal, backward compatible, and only affects cases where the placeholder is explicitly used.

I believe this fits naturally into the exporter’s responsibility, since it already performs Pod discovery and constructs the scrape targets based on Pod metadata.

Feedback is welcome.
