### PR TITLE
helm chart improvements

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
   config.yml: |-
   {{- if .Values.customConfig.enabled }}
     {{- .Values.customConfig.config | nindent 4 }}
+  {{- else if .Values.logstash.kubernetes.enabled }}
+    kubernetes:
+      {{- .Values.logstash.kubernetes | toYaml | nindent 6 }}
   {{- else }}
     logstash:
       instances:

--- a/chart/templates/service-monitor.yaml
+++ b/chart/templates/service-monitor.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "logstash-exporter.fullname" . }}
+  labels:
+    app: {{ include "logstash-exporter.name" . }}
+    release: {{ .Release.Name }}
+  labels: 
+    app.name: {{ .Values.app }}  
+    {{- with .Values.serviceMonitor.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "logstash-exporter.name" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+    - port: http
+      path: /metrics
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -278,3 +278,18 @@ rbac:
       ## @param rbac.rules[0].verbs Allowed verbs for the specified resources
       ##
       verbs: ["get", "list", "watch"]
+
+## @section serviceMonitor settings for Kubernetes controller
+##
+serviceMonitor:
+  ## @param serviceMonitor.enabled Create ServiceMonitor resources
+  ##
+  enabled: false
+  ## @param serviceMonitor.labels Additional serviceMonitor labels
+  ##
+  labels: {}
+  ## @param serviceMonitor.annotations Additional serviceMonitor annotations
+  ##
+  annotations: {}
+
+


### PR DESCRIPTION
Hi.

The helm chart did not include kubernetes configs in the configmap. Also I added a service monitor that can be used by prometheus operator so that the metrics exposed by logstash exporter can be scraped.